### PR TITLE
Use NANP number validation, not US.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,10 @@
-Revision history for Perl module Foo::Bar
+Revision history for CollectiveVoice
+
+1.0.3 YYYY-MM-DD
+
+  * Pass rating and rating description to the email template
+  * Update email template to include rating details
+  * Bugfix: empty phone number field caused an error
 
 1.0.2 2020-12-29
 

--- a/Changes
+++ b/Changes
@@ -17,4 +17,4 @@ Revision history for Perl module Foo::Bar
 
 1.0.0 2020-12-14
 
-  * Inital public release
+  * Initial public release

--- a/cpanfile
+++ b/cpanfile
@@ -58,7 +58,7 @@ requires 'Server::Starter';
 requires 'Email::Valid';
 requires 'Email::SendGrid::V3';
 requires 'Number::Phone';
-requires 'Number::Phone::US';
+requires 'Number::Phone::NANP';
 
 # Expect this list to get pruned, not sure how some are different than others
 on 'develop' => sub {

--- a/lib/CV.pm
+++ b/lib/CV.pm
@@ -72,12 +72,12 @@ post '/feedback' => sub {
     my $phone_number = body_parameters->get( 'phone_number' );
     my $phone;
     if( $phone_number ) {
-        $phone = Number::Phone->new( 'US', $phone_number );
+        $phone = Number::Phone->new( 'NANP', $phone_number );
         if( !defined $phone or not $phone->is_valid ) {
             $errors{ bad_phone } = 'Please enter a valid phone number.';
         }
         else {
-          $phone = $phone->format_for_country('US');
+          $phone = $phone->format_for_country('NANP');
         }
     }
 

--- a/lib/CV.pm
+++ b/lib/CV.pm
@@ -7,7 +7,7 @@ use Email::Valid;
 use Number::Phone;
 
 # Semantic versioning FTW
-our $VERSION = '1.0.2';
+our $VERSION = '1.0.3';
 
 # Layout MUST be set no later than the before hook!
 hook 'before' => sub {
@@ -76,7 +76,13 @@ post '/feedback' => sub {
         if( !defined $phone or not $phone->is_valid ) {
             $errors{ bad_phone } = 'Please enter a valid phone number.';
         }
+        else {
+          $phone = $phone->format_for_country('US');
+        }
     }
+
+    my $rating      = body_parameters->get( 'rating' );
+    my $rating_text = body_parameters->get( 'rating_text' );
 
     my $feedback = body_parameters->get( 'feedback' );
     $errors{ no_feedback } = 'Please provide some feedback.' unless $feedback;
@@ -95,7 +101,9 @@ post '/feedback' => sub {
                         template 'email_feedback', {
                             full_name     => $name,
                             email_address => $email_address,
-                            phone_number  => $phone->format_for_country('US'),
+                            phone_number  => $phone,
+                            rating        => $rating,
+                            rating_text   => $rating_text,
                             feedback      => $feedback,
                             company_name  => config->{'company_name'},
                         },{ layout => undef }

--- a/views/email_feedback.tt
+++ b/views/email_feedback.tt
@@ -3,9 +3,9 @@ You've received the following feedback on [% company_name | html_entity %] throu
 * Sender's Name: [% full_name | html_entity %]
 * Email Address: [% email_address | html_entity %]
 * Phone Number:  [% phone_number | html_entity %]
-* Feedback Given: 
+* Rating: [% rating_text %] ([% rating %])
+* Feedback Given:
     "[% feedback | html_entity %]"
 
 Thank you,
 -- Collective Voice
-


### PR DESCRIPTION
In pre-release testing, we stumbled across a number that didn't work
because it was from a non-US area code, even though it was a valid 10
digit phone number. During research, I found out about NANP, or North
American Numbering Plan. Long story short: it was a phone number
allocation plan developed by AT&T to standardize phone number addressing
and allocation across the US and North America.

I am classifying this a bug as the current code inadvertently excludes
Canada and other non-US countries/territories in North America from
submitting feedback. Maybe that's desirable, maybe not, but I think this
is more robust and complete.