### PR TITLE
Use NANP number validation, not US.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -58,7 +58,7 @@ requires 'Server::Starter';
 requires 'Email::Valid';
 requires 'Email::SendGrid::V3';
 requires 'Number::Phone';
-requires 'Number::Phone::US';
+requires 'Number::Phone::NANP';
 
 # Expect this list to get pruned, not sure how some are different than others
 on 'develop' => sub {

--- a/lib/CV.pm
+++ b/lib/CV.pm
@@ -72,12 +72,12 @@ post '/feedback' => sub {
     my $phone_number = body_parameters->get( 'phone_number' );
     my $phone;
     if( $phone_number ) {
-        $phone = Number::Phone->new( 'US', $phone_number );
+        $phone = Number::Phone->new( 'NANP', $phone_number );
         if( !defined $phone or not $phone->is_valid ) {
             $errors{ bad_phone } = 'Please enter a valid phone number.';
         }
         else {
-          $phone = $phone->format_for_country('US');
+          $phone = $phone->format_for_country('NANP');
         }
     }
 


### PR DESCRIPTION
In pre-release testing, we stumbled across a number that didn't work because it was from a non-US area code, even though it was a valid 10 digit phone number. During research, I found out about NANP, or North American Numbering Plan. Long story short: it was a phone number allocation plan developed by AT&T to standardize phone number addressing and allocation across the US and North America.

I am classifying this a bug as the current code inadvertently excludes Canada and other non-US countries/territories in North America from submitting feedback. Maybe that's desirable, maybe not, but I think this is more robust and complete.