### PR TITLE
Reimplement email using Email::Sender, not an API.

### DIFF
--- a/config_local.yml
+++ b/config_local.yml
@@ -1,7 +1,7 @@
 company_name: "Acme Widgets, Inc."
 company_url: "https://www.knowmad.com"
 contact_email:
-   - webmaster@knowmad.com
+    - testname@yourdomain.com
 company_logo: "images/Acme-corp.png"
 
 # For tailwind UI, consider making bg 400 grey and fg 800 blue
@@ -22,6 +22,13 @@ review_sites:
         url: https://upcity.com/local-marketing-agencies/profiles/knowmad#review
         logo: /images/logos/upcity-logo.png
 
-sendgrid:
-    api_key: your_key_goes_here
-    from: 'noreply@collectivevoice.com'
+# Ports can be:
+# 25 - unencrypted
+# 587: TLS
+# 465: SSL
+mailserver:
+    from: "no-reply@yourdomain.com"
+    host: smtp.yourhost.net
+    username: email_username
+    password: foobar
+    port: 587

--- a/cpanfile
+++ b/cpanfile
@@ -56,7 +56,9 @@ requires 'Dancer2::Plugin::Adapter';
 requires 'Starlet';
 requires 'Server::Starter';
 requires 'Email::Valid';
-requires 'Email::SendGrid::V3';
+requires 'Email::Sender::Simple';
+requires 'Email::Simple';
+requires 'Authen::SASL';
 requires 'Number::Phone';
 requires 'Number::Phone::US';
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -120,6 +120,27 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0
       perl 5.008008
+  Authen-SASL-2.16
+    pathname: G/GB/GBARR/Authen-SASL-2.16.tar.gz
+    provides:
+      Authen::SASL 2.16
+      Authen::SASL::CRAM_MD5 2.14
+      Authen::SASL::EXTERNAL 2.14
+      Authen::SASL::Perl 2.14
+      Authen::SASL::Perl::ANONYMOUS 2.14
+      Authen::SASL::Perl::CRAM_MD5 2.14
+      Authen::SASL::Perl::DIGEST_MD5 2.14
+      Authen::SASL::Perl::EXTERNAL 2.14
+      Authen::SASL::Perl::GSSAPI 0.05
+      Authen::SASL::Perl::LOGIN 2.14
+      Authen::SASL::Perl::Layer 2.14
+      Authen::SASL::Perl::PLAIN 2.14
+    requirements:
+      Digest::HMAC_MD5 0
+      Digest::MD5 0
+      ExtUtils::MakeMaker 6.42
+      Test::More 0
+      perl 5.005
   B-Hooks-EndOfScope-0.24
     pathname: E/ET/ETHER/B-Hooks-EndOfScope-0.24.tar.gz
     provides:
@@ -517,7 +538,6 @@ DISTRIBUTIONS
       HTTP::Date 0
       HTTP::Headers::Fast 0.21
       HTTP::Tiny 0
-      HTTP::XSCookies 0.000007
       Hash::Merge::Simple 0
       Hash::MultiValue 0
       Import::Into 0
@@ -752,6 +772,17 @@ DISTRIBUTIONS
     requirements:
       Devel::StackTrace 0
       ExtUtils::MakeMaker 0
+  Digest-HMAC-1.03
+    pathname: G/GA/GAAS/Digest-HMAC-1.03.tar.gz
+    provides:
+      Digest::HMAC 1.03
+      Digest::HMAC_MD5 1.01
+      Digest::HMAC_SHA1 1.03
+    requirements:
+      Digest::MD5 2
+      Digest::SHA 1
+      ExtUtils::MakeMaker 0
+      perl 5.004
   Dist-CheckConflicts-0.11
     pathname: D/DO/DOY/Dist-CheckConflicts-0.11.tar.gz
     provides:
@@ -764,6 +795,120 @@ DISTRIBUTIONS
       base 0
       strict 0
       warnings 0
+  Email-Abstract-3.008
+    pathname: R/RJ/RJBS/Email-Abstract-3.008.tar.gz
+    provides:
+      Email::Abstract 3.008
+      Email::Abstract::EmailMIME 3.008
+      Email::Abstract::EmailSimple 3.008
+      Email::Abstract::MIMEEntity 3.008
+      Email::Abstract::MailInternet 3.008
+      Email::Abstract::MailMessage 3.008
+      Email::Abstract::Plugin 3.008
+    requirements:
+      Carp 0
+      Email::Simple 1.998
+      ExtUtils::MakeMaker 0
+      MRO::Compat 0
+      Module::Pluggable 1.5
+      Scalar::Util 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Email-Address-1.912
+    pathname: R/RJ/RJBS/Email-Address-1.912.tar.gz
+    provides:
+      Email::Address 1.912
+    requirements:
+      ExtUtils::MakeMaker 0
+      overload 0
+      strict 0
+      warnings 0
+  Email-Address-XS-1.04
+    pathname: P/PA/PALI/Email-Address-XS-1.04.tar.gz
+    provides:
+      Email::Address::XS 1.04
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      XSLoader 0
+      base 0
+      overload 0
+      perl 5.006000
+      strict 0
+      warnings 0
+  Email-Date-Format-1.005
+    pathname: R/RJ/RJBS/Email-Date-Format-1.005.tar.gz
+    provides:
+      Email::Date::Format 1.005
+    requirements:
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Time::Local 0
+      strict 0
+      warnings 0
+  Email-MIME-1.949
+    pathname: R/RJ/RJBS/Email-MIME-1.949.tar.gz
+    provides:
+      Email::MIME 1.949
+      Email::MIME::Creator 1.949
+      Email::MIME::Encode 1.949
+      Email::MIME::Header 1.949
+      Email::MIME::Header::AddressList 1.949
+      Email::MIME::Modifier 1.949
+    requirements:
+      Carp 0
+      Email::Address::XS 0
+      Email::MIME::ContentType 1.023
+      Email::MIME::Encodings 1.314
+      Email::MessageID 0
+      Email::Simple 2.212
+      Email::Simple::Creator 0
+      Email::Simple::Header 0
+      Encode 1.9801
+      ExtUtils::MakeMaker 0
+      MIME::Base64 0
+      MIME::Types 1.13
+      Module::Runtime 0
+      Scalar::Util 0
+      parent 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Email-MIME-ContentType-1.026
+    pathname: R/RJ/RJBS/Email-MIME-ContentType-1.026.tar.gz
+    provides:
+      Email::MIME::ContentType 1.026
+    requirements:
+      Carp 0
+      Encode 2.87
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Text::Unidecode 0
+      strict 0
+      warnings 0
+  Email-MIME-Encodings-1.315
+    pathname: R/RJ/RJBS/Email-MIME-Encodings-1.315.tar.gz
+    provides:
+      Email::MIME::Encodings 1.315
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.30
+      MIME::Base64 3.05
+      MIME::QuotedPrint 3.05
+      strict 0
+      warnings 0
+  Email-MessageID-1.406
+    pathname: R/RJ/RJBS/Email-MessageID-1.406.tar.gz
+    provides:
+      Email::MessageID 1.406
+    requirements:
+      ExtUtils::MakeMaker 0
+      Sys::Hostname 0
+      overload 0
+      strict 0
+      warnings 0
   Email-SendGrid-V3-v0.900.1
     pathname: G/GS/GSG/Email-SendGrid-V3-v0.900.1.tar.gz
     provides:
@@ -772,6 +917,74 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 7.1101
       JSON 0
       namespace::clean 0
+  Email-Sender-1.300035
+    pathname: R/RJ/RJBS/Email-Sender-1.300035.tar.gz
+    provides:
+      Email::Sender 1.300035
+      Email::Sender::Failure 1.300035
+      Email::Sender::Failure::Multi 1.300035
+      Email::Sender::Failure::Permanent 1.300035
+      Email::Sender::Failure::Temporary 1.300035
+      Email::Sender::Manual 1.300035
+      Email::Sender::Manual::QuickStart 1.300035
+      Email::Sender::Role::CommonSending 1.300035
+      Email::Sender::Role::HasMessage 1.300035
+      Email::Sender::Simple 1.300035
+      Email::Sender::Success 1.300035
+      Email::Sender::Success::Partial 1.300035
+      Email::Sender::Transport 1.300035
+      Email::Sender::Transport::DevNull 1.300035
+      Email::Sender::Transport::Failable 1.300035
+      Email::Sender::Transport::Maildir 1.300035
+      Email::Sender::Transport::Mbox 1.300035
+      Email::Sender::Transport::Print 1.300035
+      Email::Sender::Transport::SMTP 1.300035
+      Email::Sender::Transport::SMTP::Persistent 1.300035
+      Email::Sender::Transport::Sendmail 1.300035
+      Email::Sender::Transport::Test 1.300035
+      Email::Sender::Transport::Wrapper 1.300035
+      Email::Sender::Util 1.300035
+    requirements:
+      Carp 0
+      Email::Abstract 3.006
+      Email::Address 0
+      Email::Simple 1.998
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      File::Basename 0
+      File::Path 2.06
+      File::Spec 0
+      IO::File 1.11
+      IO::Handle 0
+      List::Util 1.45
+      Module::Runtime 0
+      Moo 2.000000
+      Moo::Role 0
+      MooX::Types::MooseLike 0.15
+      MooX::Types::MooseLike::Base 0
+      Net::SMTP 3.07
+      Scalar::Util 0
+      Sub::Exporter 0
+      Sub::Exporter::Util 0
+      Sys::Hostname 0
+      Throwable::Error 0.200003
+      Try::Tiny 0
+      strict 0
+      utf8 0
+      warnings 0
+  Email-Simple-2.216
+    pathname: R/RJ/RJBS/Email-Simple-2.216.tar.gz
+    provides:
+      Email::Simple 2.216
+      Email::Simple::Creator 2.216
+      Email::Simple::Header 2.216
+    requirements:
+      Carp 0
+      Email::Date::Format 0
+      ExtUtils::MakeMaker 0
+      perl 5.008
+      strict 0
+      warnings 0
   Email-Valid-1.202
     pathname: R/RJ/RJBS/Email-Valid-1.202.tar.gz
     provides:
@@ -1382,6 +1595,25 @@ DISTRIBUTIONS
       File::Path 2.0606
       File::Spec 0.82
       Test::More 0.45
+  MIME-Types-2.18
+    pathname: M/MA/MARKOV/MIME-Types-2.18.tar.gz
+    provides:
+      MIME::Type 2.18
+      MIME::Types 2.18
+      MojoX::MIME::Types 2.18
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Spec 0
+      List::Util 0
+      Test::More 0.47
+  MRO-Compat-0.13
+    pathname: H/HA/HAARG/MRO-Compat-0.13.tar.gz
+    provides:
+      MRO::Compat 0.13
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
   MailTools-2.21
     pathname: M/MA/MARKOV/MailTools-2.21.tar.gz
     provides:
@@ -2876,6 +3108,29 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0
       perl 5.008001
+  Text-Unidecode-1.30
+    pathname: S/SB/SBURKE/Text-Unidecode-1.30.tar.gz
+    provides:
+      Text::Unidecode 1.30
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008
+  Throwable-0.200013
+    pathname: R/RJ/RJBS/Throwable-0.200013.tar.gz
+    provides:
+      StackTrace::Auto 0.200013
+      Throwable 0.200013
+      Throwable::Error 0.200013
+    requirements:
+      Carp 0
+      Devel::StackTrace 1.32
+      ExtUtils::MakeMaker 0
+      Module::Runtime 0.002
+      Moo 1.000001
+      Moo::Role 0
+      Scalar::Util 0
+      Sub::Quote 0
+      overload 0
   TimeDate-2.32
     pathname: A/AT/ATOOMIC/TimeDate-2.32.tar.gz
     provides:

--- a/lib/CV/Base.pm
+++ b/lib/CV/Base.pm
@@ -18,7 +18,7 @@ our @IMPORT_MODULES = (
 our %IMPORT_BUNDLES = (
     CLI    => [ qw( Getopt::Long )],
     WebApp => [ qw( Dancer2 Dancer2::Plugin::Minify Dancer2::Plugin::Deferred 
-        Dancer2::Plugin::Adapter Dancer2::Plugin::Syntax::GetPost Email::SendGrid::V3 )],
+        Dancer2::Plugin::Adapter Dancer2::Plugin::Syntax::GetPost Email::Valid Number::Phone )],
     Object => [ qw( Moo )],
     Test   => [ qw( Test::Most )],
 );

--- a/t/backend/email.t
+++ b/t/backend/email.t
@@ -1,10 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More skip_all => 'need to rewrite for Email::Sender';
-
-
-
+use Dancer2;
 use Test::More import => ['!pass'];
 use Test::WWW::Mechanize::PSGI;
 BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' } # Don't send emails!
@@ -30,6 +27,9 @@ $mech->post_ok( '/feedback', {
 
 # Check for an email with feedback details
 my @good_emails = Email::Sender::Simple->default_transport->deliveries;
-cmp_ok( scalar @good_emails, '==', 1, "...and we sent an email when a complete form was received." );
+my $recipients  = scalar config->{ contact_email }->@*;
+cmp_ok( scalar @good_emails, '==', $recipients, 
+    "...and we sent an email to each recipient when a complete form was received." 
+);
 
 done_testing();


### PR DESCRIPTION
Instead of being tied to SendGrid, we can now send via any host that supports SMTP. By using Email::Sender::Simple, we can now test outgoing emails, and as such, have removed the skip_all declaration in email.t.

Some other dependencies have changed, notably the inclusion of a lot of Email::* modules, and the removal of the SendGrid API.